### PR TITLE
Remove no-op 'g' flag

### DIFF
--- a/lib/linkify-it-rb/index.rb
+++ b/lib/linkify-it-rb/index.rb
@@ -205,7 +205,7 @@ class Linkify
 
     # (?!_) cause 1.5x slowdown
     @re[:schema_test]   = Regexp.new('(^|(?!_)(?:[><\uff5c]|' + @re[:src_XPCc] + '))(' + slist + ')', 'i')
-    @re[:schema_search] = Regexp.new('(^|(?!_)(?:[><\uff5c]|' + @re[:src_XPCc] + '))(' + slist + ')', 'ig')
+    @re[:schema_search] = Regexp.new('(^|(?!_)(?:[><\uff5c]|' + @re[:src_XPCc] + '))(' + slist + ')', 'i')
 
     @re[:pretest]       = Regexp.new(
                               '(' + @re[:schema_test].source + ')|' +


### PR DESCRIPTION
In Ruby 3.2.0, invalid options passed to `Regexp.new` will throw an `ArgumentError` with a method such as

```plain
unknown regexp option: ig
```

I think this was introduced in https://github.com/ruby/ruby/pull/6039.

While the `i` flag is supported, I don't think the `g` flag has ever been supported in Ruby unlike other language regexp implementations. [For instance, here are the options for 2.4.1, which don't include `g`](https://ruby-doc.org/core-2.4.1/Regexp.html#class-Regexp-label-Options).

I believe that removing the `g` option here will enable this gem to continue working with older versions of Ruby while also continuing to work with 3.2+.

If there is anything else I can do to help further with this PR please let me know!

## Reproduction against `master`

1. Set local Ruby to 3.1.2 and run `rake spec`, observe suite passes
2. Set local Ruby to 3.2.0 and run `rake spec`, observe suite fails with:
   ```plain
   An error occurred while loading ./spec/linkify-it-rb/test_spec.rb.
   Failure/Error: @re[:schema_search] = Regexp.new('(^|(?!_)(?:[><\uff5c]|' + @re[:src_XPCc] + '))(' + slist + ')', 'ig')
    
   ArgumentError:
     unknown regexp option: ig
   # ./lib/linkify-it-rb/index.rb:208:in `initialize'
   # ./lib/linkify-it-rb/index.rb:208:in `new'
   # ./lib/linkify-it-rb/index.rb:208:in `compile'
   # ./lib/linkify-it-rb/index.rb:338:in `initialize'
   # ./spec/linkify-it-rb/test_spec.rb:6:in `new'
   # ./spec/linkify-it-rb/test_spec.rb:6:in `block in <top (required)>'
   # ./spec/linkify-it-rb/test_spec.rb:4:in `<top (required)>'
   No examples found.
   ```

## Testing the fix

1. Set local Ruby to 3.1.2 and run `rake spec`, observe suite passes
2. Set local Ruby to 3.2.0 and run `rake spec`, observe suite passes